### PR TITLE
Changing icon to play after finishing playing

### DIFF
--- a/Player/Player.jsx
+++ b/Player/Player.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, Fragment } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import WaveSurfer from "wavesurfer.js";
 import { FaPlay, FaUndo, FaRedo } from "react-icons/fa";
 import { FaPause } from "react-icons/fa";
@@ -70,7 +70,7 @@ export default function Player(props) {
                 }
                 wavesurfer.zoom(props.zoom);
             });
-            
+
             if (props?.events) {
                 Object.entries(props.events).map(([key, value]) => {
                     waveSurfer.on(key, value);

--- a/Player/Player.jsx
+++ b/Player/Player.jsx
@@ -74,6 +74,10 @@ export default function Player(props) {
                 wavesurfer.zoom(props.zoom);
             });
 
+            wavesurfer.on("finish", () => {
+                setPlayingAudio(false);
+            });
+
             if (props?.events) {
                 Object.entries(props.events).map(([key, value]) => {
                     waveSurfer.on(key, value);
@@ -141,12 +145,12 @@ export default function Player(props) {
                         {playingAudio ? (
                             <FaPause
                                 style={{ margin: "20px", cursor: "pointer" }}
-                                onClick={() => (playingAudio ? pauseAudio() : playAudio())}
+                                onClick={pauseAudio}
                             />
                         ) : (
                                 <FaPlay
                                     style={{ margin: "20px", cursor: "pointer" }}
-                                    onClick={() => (playingAudio ? pauseAudio() : playAudio())}
+                                    onClick={playAudio}
                                 />
                             )}
                         <span

--- a/Player/Player.jsx
+++ b/Player/Player.jsx
@@ -5,6 +5,8 @@ import { FaPause } from "react-icons/fa";
 
 export default function Player(props) {
 
+    const wrapperRef = useRef();
+
     const waveformRef = useRef();
     const trackRef = useRef(); // Separated track playing from waveplayer to support bigger audio files
     const [waveSurfer, setWaveSurfer] = useState(null); // Holds the reference to created wavesurfer object
@@ -45,18 +47,19 @@ export default function Player(props) {
 
     useEffect(() => {
         if (waveformRef.current && trackRef.current && !props.hideWave) {
+            const waveSettings = {
+                backend: "MediaElement",
+                container: wrapperRef.current.querySelector('.waveform'),
+                responsive: true
+            }
+
             const wavesurfer = props.waveStyles
                 ? WaveSurfer.create({
                     ...props.waveStyles,
-                    container: "#waveform",
-                    responsive: true,
-                    backend: "MediaElement"
+                    ...waveSettings
                 })
-                : WaveSurfer.create({
-                    container: "#waveform",
-                    responsive: true,
-                    backend: "MediaElement"
-                });
+                : WaveSurfer.create(waveSettings);
+
                 // Load the waveForm json if provided
             props.waveJson
                 ? wavesurfer.load(trackRef.current)
@@ -88,6 +91,7 @@ export default function Player(props) {
     return (
         <>
             <div
+                ref={wrapperRef}
                 style={props.containerStyles ? {
                     display: "flex",
                     flexDirection: "row", ...props.containerStyles
@@ -119,7 +123,7 @@ export default function Player(props) {
                     }}
                 >
                     <div>
-                        {!props.hideWave && <div ref={waveformRef} id="waveform" />}
+                        {!props.hideWave && <div ref={waveformRef} className="waveform" />}
                         <audio src={props.audioUrl} ref={trackRef} />
                     </div>
                     <div

--- a/Player/Player.jsx
+++ b/Player/Player.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { Fragment, useState, useEffect, useRef } from "react";
 import WaveSurfer from "wavesurfer.js";
 import { FaPlay, FaUndo, FaRedo } from "react-icons/fa";
 import { FaPause } from "react-icons/fa";


### PR DESCRIPTION
Since the player was globally searching for `#waveform` when creating the wave, in the case where we had multiple players displayed at the same time, all the waves were rendered in the same place.

Now it's looking for a relative class element inside the player.